### PR TITLE
Feature: Initrd Release flag/file

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -369,6 +369,7 @@ buildAgent() {
 	cd - >/dev/null
 	export GOPATH=${OLD_GOPATH}
 
+	logDebug "Copying shared libraries"
 	copyShareObjects "${BUILD_DIR}/bin/rebuild-agent" "${BUILD_DIR}"
 
 	logInfo "Finished building and installing the Rebuild Agent"

--- a/build.sh
+++ b/build.sh
@@ -19,6 +19,7 @@
 
 pushd `dirname $0` > /dev/null
 SCRIPTPATH=`pwd`
+VERSION=`git describe --tags --abbrev=5`
 popd > /dev/null
 
 ## Global
@@ -393,6 +394,9 @@ packageInitrd() {
 
 	logDebug "Copying initrd sources into build directory" && \cp -rf ${INITRD_SRC}/* ${BUILD_DIR}
 
+	logDebug "Writing initrd release file to build directory"
+	echo ${VERSION} > ${BUILD_DIR}/lib/rebuild/initrd-release
+
 	logDebug "Changing directories into initrd build directory" && cd ${BUILD_DIR}
 
 	logDebug "Build CPIO package and compressing to output file"
@@ -460,6 +464,7 @@ showHelp() {
 #####
 
 logDebug "Detecting my full path as: ${SCRIPTPATH}"
+logDebug "Detecting initrd version as: ${VERSION}"
 
 if [ $# == 0 ]; then
 	showHelp


### PR DESCRIPTION
The `packageInitrd` task in the build script has been updated so that it will now write a file to the build directory, before packaging, that contains the release string.

This file is required by the Rebuild Agent for it to display it in the banner so users know what version of the Initrd they are running.